### PR TITLE
Fix Java LSP Config

### DIFF
--- a/ftplugin/java.lua
+++ b/ftplugin/java.lua
@@ -1,5 +1,7 @@
+local on_attach = require("config.on_attach")
 local config = {
     cmd = {vim.fn.expand('~/.local/share/nvim/mason/bin/jdtls')},
     root_dir = vim.fs.dirname(vim.fs.find({'gradlew', '.git', 'mvnw'}, { upward = true })[1]),
+    on_attach = on_attach,
 }
 require('jdtls').start_or_attach(config)

--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,4 @@
-print("hello from init")
-
 require("config.lazy")
-
 
 -- These keymaps make development much more quicker
 vim.keymap.set("n", "<space><space>x", "<cmd>source %<CR>")

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -1,5 +1,3 @@
-print("hello from lazy")
-
 -- Bootstrap lazy.nvim
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not (vim.uv or vim.loop).fs_stat(lazypath) then

--- a/lua/config/on_attach.lua
+++ b/lua/config/on_attach.lua
@@ -1,0 +1,37 @@
+local buf = vim.lsp.buf
+
+
+-- custom extend function so that we are not repeating the opt in a bunch of places
+local opts = { noremap = true, silent = true, }
+local extend = function(tbl, desc)
+  return vim.tbl_extend("error", tbl, desc)
+end
+
+-- these keymaps will work only if a language server can be attached to the current buffer
+return function(client, bufnr)
+  -- Enable completion triggered by <c-x><c-o>
+  vim.api.nvim_set_option_value('omnifunc', 'v:lua.vim.lsp.omnifunc', { buf = bufnr })
+
+  -- handlers
+  vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, { border = "single", color = "red" })
+  vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, { border = "single" })
+
+  -- Mappings
+  vim.keymap.set('n', 'gD', buf.declaration, extend(opts, { desc = "Buffer declarations" }))
+  vim.keymap.set('n', 'gd', buf.definition, extend(opts, { desc = "Go to definition" }))
+  vim.keymap.set('n', 'K', buf.hover, extend(opts, { desc = "View definition" }))
+  vim.keymap.set('n', 'gi', buf.implementation, extend(opts, { desc = "Get implementation" }))
+  vim.keymap.set('n', 'SH', buf.signature_help, extend(opts, { desc = "Signature help" }))
+  vim.keymap.set('n', '<space>wa', buf.add_workspace_folder, extend(opts, { desc = "Add workspace to folder" }))
+  vim.keymap.set('n', '<space>wr', buf.remove_workspace_folder, extend(opts, { desc = "remove workspace from folder" }))
+  vim.keymap.set('n', '<space>wl', buf.list_workspace_folders, extend(opts, { desc = "List workspace folders" }))
+  vim.keymap.set('n', '<space>D', buf.type_definition, extend(opts, { desc = "Type definition" }))
+  vim.keymap.set('n', '<space>rn', buf.rename, extend(opts, { desc = "Rename" }))
+  vim.keymap.set('n', '<space>ca', buf.code_action, extend(opts, { desc = "Code action" }))
+  vim.keymap.set('n', 'gr', buf.references, extend(opts, { desc = "Get references" }))
+  vim.keymap.set('n', '<space>e', vim.diagnostic.open_float, extend(opts, { desc = "Open diagnostic on current line" }))
+  vim.keymap.set('n', '[d', vim.diagnostic.goto_next, extend(opts, { desc = "Jump to next diagnostic" }))
+  vim.keymap.set('n', ']d', vim.diagnostic.goto_prev, extend(opts, { desc = "Jump to previous diagnostic" }))
+  vim.keymap.set('n', '<space>f', vim.lsp.buf.format, extend(opts, { desc = "Format file" }))
+
+end

--- a/lua/config/plugins/cmp.lua
+++ b/lua/config/plugins/cmp.lua
@@ -1,0 +1,77 @@
+return {
+  {
+    "hrsh7th/nvim-cmp",
+    dependencies = {
+      "hrsh7th/cmp-buffer",
+      "hrsh7th/cmp-path",       -- completion sources for files in proj
+      "hrsh7th/cmp-nvim-lua",   -- completion for neovim apis in your lua configs
+      "hrsh7th/cmp-nvim-lsp",   -- better completion sources from every lsp
+    },
+
+    config = function()
+      local cmp = require("cmp")
+      cmp.setup({
+        mapping = {
+          ['<C-d>'] = cmp.mapping.scroll_docs(-4),
+          ['<C-f>'] = cmp.mapping.scroll_docs(4),
+          ['<C-Space>'] = cmp.mapping.complete(),
+          ['<C-e>'] = cmp.mapping.close(),
+          ['<CR>'] = cmp.mapping.confirm({
+            select = true,
+            behavior = cmp.ConfirmBehavior.replace
+          }),
+          ["<C-p>"] = cmp.mapping.select_prev_item(),
+          ["<C-n>"] = cmp.mapping.select_next_item()
+        },
+        sources = {
+          { name = 'nvim_lsp' },
+          { name = 'path' },
+          { name = 'buffer',  keyword_length = 8 },
+        },
+        formatting = {
+          format = function(entry, vim_item)
+            vim_item.menu = ({
+              nvim_lsp = "[LSP]",
+              buffer = "[Buffer]",
+              nvim_lua = "[Lua]",
+              luasnip = "[luasnip]",
+            })[entry.source.name]
+
+            -- make sure your terminal font supports the below icons
+            -- would recommend installing a nerd font just to be safe
+            vim_item.kind = ({
+              Text          = ' Text',
+              Method        = '󰆧 Method',
+              Function      = '󰊕 Function',
+              Constructor   = ' Constructor',
+              Field         = ' Field',
+              Variable      = ' Variable',
+              Class         = ' Class',
+              Interface     = ' Interface',
+              Module        = ' Module',
+              Property      = ' Property',
+              Unit          = ' Unit',
+              Value         = '󰎠 Value',
+              Enum          = ' Enum',
+              Keyword       = ' Keyword',
+              Snippet       = ' Snippet',
+              Color         = ' Color',
+              File          = ' File',
+              Reference     = ' Reference',
+              Folder        = ' Folder',
+              EnumMember    = ' EnumMember',
+              Constant      = ' Constant',
+              Struct        = ' Struct',
+              Event         = ' Event',
+              Operator      = ' Operator',
+              TypeParameter = ' TypeParameter',
+            })[vim_item.kind]
+            return vim_item
+          end,
+        },
+      })
+
+    end
+  },
+
+}

--- a/lua/config/plugins/treesitter.lua
+++ b/lua/config/plugins/treesitter.lua
@@ -1,31 +1,35 @@
 -- A must have parser
 return {
   {
-    "nvim-treesitter/nvim-treesitter", 
+    "nvim-treesitter/nvim-treesitter",
     build = ":TSUpdate",
     config = function()
       require'nvim-treesitter.configs'.setup {
-	-- A list of parser names, or "all" (the listed parsers MUST always be installed)
-	ensure_installed = { "c", "lua", "vim", "vimdoc", "query", "markdown", "markdown_inline", "java"},
+        -- A list of parser names, or "all" (the listed parsers MUST always be installed)
+        ensure_installed = { "c", "lua", "vim", "vimdoc", "query", "markdown", "markdown_inline", "java"},
 
+        -- Automatically install missing parsers when entering buffer
+        -- Recommendation: set to false if you don't have `tree-sitter` CLI installed locally
+        auto_install = true,
 
-	-- Automatically install missing parsers when entering buffer
-	-- Recommendation: set to false if you don't have `tree-sitter` CLI installed locally
-	auto_install = true,
+        highlight = {
+          enable = true,
+          disable = function(lang, buf)
+              local max_filesize = 100 * 1024 -- 100 KB
+              local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
+              if ok and stats and stats.size > max_filesize then
+                return true
+              end
+          end,
+          additional_vim_regex_highlighting = false,
+        },
 
-	highlight = {
-	  enable = true,
+        -- defaults
+        syn_install = false,
 
-	  disable = function(lang, buf)
-	      local max_filesize = 100 * 1024 -- 100 KB
-	      local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
-	      if ok and stats and stats.size > max_filesize then
-		  return true
-	      end
-	  end,
-	  additional_vim_regex_highlighting = false,
-	},
       }
-      end
-  }
+
+    end
+  },
+
 }


### PR DESCRIPTION
Hey there! I think this PR should do most of what you need but feel free to provide feedback so that we can iterate on this. Here's a summary of what I think occurred:

## Summary

1. you set up your LSP server config correctly.
2. However, it is possible that you did not download the actual LSP server itself. I downloaded it with `:Mason`. The LSP worked out of the box without me having to change your config. However: 
3. It *appeared* as though your LSP was not working, because you did not have autocomplete set up. However, I verified that the lsp was working by manually calling some of neovim's APIs, (for example, `:lua vim.lsp.buf.definition()` showed me the correct definition. I also verified with `:LspInfo` that the LSP server did in fact attach. Here is the output (again, at this point I didn't even touch your config):

```

==============================================================================
lspconfig: require("lspconfig.health").check()

LSP configs active in this session (globally) ~
- Configured servers: lua_ls
- OK Deprecated servers: (none)

LSP configs active in this buffer (bufnr: 17) ~
- Language client log: ~/.local/state/nvim/lsp.log
- Detected filetype: `java`
- 1 client(s) attached to this buffer
- Client: `jdtls` (id: 1, bufnr: [17])
  root directory:    ~/Documents/learning/java/test-gradle/
  filetypes:         
  cmd:               ~/.local/share/nvim/mason/bin/jdtls
  version:           `usage: jdtls [-h] [--validate-java-version] [--no-validate-java-version]…` (Failed to get version) Tried:
  `/home/chrisv/.local/share/nvim/mason/bin/jdtls --version`
  `/home/chrisv/.local/share/nvim/mason/bin/jdtls -version`
  `/home/chrisv/.local/share/nvim/mason/bin/jdtls version`
  `/home/chrisv/.local/share/nvim/mason/bin/jdtls --help`
  
  executable:        true
  autostart:         false

- 

```

Therefore, my contribution in this PR was merely to add functionality (i.e. plugins) to your PR so that it *feels* like the LSP is working. I was conservative with what I downloaded. I only added the `cmp` -related plugins. 

In addition, I added an `on_attach` handler so that the lsp APIs work whenever an lsp client is attached to your buffer. I think this was the last missing piece of the puzzle: even though the lsp was working, `gd` did not take you to the definition. An on attach handler had to be defined and binded in your `jdtls` plugin for neovim to take you to your function definitions. 

I downloaded `gradle` and ran `gradle init` to bootstrap a project. I verified that my changes allowed the lsp to propagate changes in the function definition to different parts of the codebase. When I added a method, or added a comment/doc to function methods, the LSP managed to pick it up. Go to definition works. And get references works.

## Recommendations for further plugins

Its always fun to add more plugins. I know you want something minimal, so I will lightly suggest these below plugins (and I can always recommend many more) that will make your quality of life easier as a developer!

* [Telescope](https://github.com/nvim-telescope/telescope.nvim): a phenomenal plugin for fuzzy searching not just files, but *many more things* ! Wanna preview colorschemes? An interface to see your current keybindings? The diagnostics in your current buffer? Telescope can show you all of that.
* [nvim-navic](https://github.com/SmiteshP/nvim-navic) This is an interface to display the current level in your code. Given that you're working in Java, I think it'd be useful to see at what "level" your cursor is (i.e., what class or method are you currently in). I use this a ton to orient myself in JSON files, and in codebases that uses a lot of classes. This plugin is supposed to be used in conjunction with your status line.
* [aerial](https://github.com/stevearc/aerial.nvim): very similar to navic, except the "level" you're in is expressed in something that looks like a file tree. So, for instance, the Aerial buffer will show an entry for a HelloWorld class, and subsequent lines for its methods. Pressing `<CR>` on those methods in Aerial jumps you to that method definition. I think its a great plugin for Java projects specifically. 
* [trouble](folke/trouble.nvim): can display all your current buffer's diagnostics (or quickfix list) in a small window at the bottom of your screen for that IDE feel. Of course pressing `<CR>` on a diagnostic in a trouble window will jump you to that diagnostic.
* [luasnip](https://github.com/L3MON4D3/LuaSnip): my preferred snip engine. But there are others. I like it because I am familiar with it and I can write my own snippets. And this plugin also offers the option to lazy load common snippets for different languages.