### PR TITLE
Config to accommodate Lombok

### DIFF
--- a/ftplugin/java.lua
+++ b/ftplugin/java.lua
@@ -1,7 +1,64 @@
-local on_attach = require("config.on_attach")
+local jdtls = require('jdtls')
+local home = os.getenv('HOME')
+local workspace_path = home .. '/.local/share/nvim/jdtls-workspace/'
+local project_name = vim.fn.fnamemodify(vim.fn.getcwd(), ':p:h:t')
+local workspace_dir = workspace_path .. project_name
+
+local extendedClientCapabilities = jdtls.extendedClientCapabilities
+
 local config = {
-    cmd = {vim.fn.expand('~/.local/share/nvim/mason/bin/jdtls')},
-    root_dir = vim.fs.dirname(vim.fs.find({'gradlew', '.git', 'mvnw'}, { upward = true })[1]),
-    on_attach = on_attach,
+  -- The command that starts the language server
+  -- See: https://github.com/eclipse/eclipse.jdt.ls#running-from-the-command-line
+  cmd = {
+
+    -- jdtls executable
+    vim.fn.expand('~/.local/share/nvim/mason/bin/jdtls'),
+
+    '-Declipse.application=org.eclipse.jdt.ls.core.id1',
+    '-Dosgi.bundles.defaultStartLevel=4',
+    '-Declipse.product=org.eclipse.jdt.ls.core.product',
+    '-Dlog.protocol=true',
+    '-Dlog.level=ALL',
+    '-Xmx1g',
+    '--add-modules=ALL-SYSTEM',
+    '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+    '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+
+
+    -- lombock setup here
+    '-javaagent:' .. home .. './local/share/nvim/mason/packages/jdtls/lombok.jar',
+
+    -- point to the correct eclipse equinox launcher
+    '-jar', vim.fn.glob(home .. '/.local/share/nvim/mason/packages/jdtls/plugins/org.eclipse.equinox.launcher_*.jar'),
+
+
+    -- NOTE: must point to correct config based on your OS
+    '-configuration', home .. '/.local/share/nvim/mason/packages/jdtls/config_mac',
+                    -- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^        ^^^^^^
+                    -- Must point to the                      Change to one of `linux`, `win` or `mac`
+                    -- eclipse.jdt.ls installation            Depending on your system.
+
+    '-data', workspace_dir,
+  },
+
+  root_dir = vim.fs.root(0, {".git", "mvnw", "gradlew", "pom.xml", "build.gradle"}),
+
+  -- Here you can configure eclipse.jdt.ls specific settings
+  settings = {
+    java = {
+      signatureHelp = { enabled = true, },
+      extendedClientCapabilities = extendedClientCapabilities,
+      maven = { downloadSources = true, },
+      references = { includeDecompiledSources = true, },
+    },
+  },
+
+  init_options = {
+    bundles = {}
+  },
+
+  on_attach = on_attach,
+
 }
-require('jdtls').start_or_attach(config)
+
+jdtls.start_or_attach(config)


### PR DESCRIPTION
Added config to accommodate lombok project. Config was copied from [here](https://github.com/mfussenegger/nvim-jdtls?tab=readme-ov-file#configuration-verbose), per the docs, and the lombok config portion was inspired from [this](https://youtu.be/C7juSZsM2Fg?si=R3lVkfUfOdN_LOtX&t=501) YouTube video. 

There are three paths described by this config. Make sure they exist!

1. the executable: `~/.local/share/nvim/mason/bin/jdtls`
2. lombok jar (automatically downloaded when included in a bundle.gradle? Run `gradle clean build` just to make sure!): `~./local/share/nvim/mason/packages/jdtls/lombok.jar`
3. an equinox launcher. Don't know what that is but it sounds important! I think should have already been downloaded by mason: `~/.local/share/nvim/mason/packages/jdtls/plugins/org.eclipse.equinox.launcher_*.jar`
4. config setting, also should have been downloaded by Mason already: `~/.local/share/nvim/mason/packages/jdtls/config_mac`

I [added lombock](https://projectlombok.org/setup/gradle) to a gradle file and saw this!


![lombok-getter](https://github.com/user-attachments/assets/cb3adecd-470b-43d5-9fd3-171fa812fcad)
![lombok-import](https://github.com/user-attachments/assets/7482949d-3a8a-4f62-80a7-1b354cbf51d8)
